### PR TITLE
Added datasets, tokenizers, and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ If you don't have so much VRAM:
 python ./src/main.py --n_layer 12 --sequence_length 256
 ```
 
+If you have **very** limited resources, try the shakespeare dataset and character-based tokenizer:
+
+```
+python ./src/main.py --n_layer=2 --n_head=4 --n_embd=128 --sequence_length=256 --dataset=shakespeare --tokenizer=character --device=cpu --vocab_size=0
+```
 
 ## Less quick start
 

--- a/src/config/base.py
+++ b/src/config/base.py
@@ -1,6 +1,7 @@
-import argparse
 import torch
+
 import distributed
+
 
 def parse_args(base_parser, args, namespace):
     parser = base_parser
@@ -20,8 +21,9 @@ def parse_args(base_parser, args, namespace):
     parser.add_argument('--eval_freq', default=200, type=int) # in iterations
     parser.add_argument('--results_base_folder', default="./exps", type=str) 
     # Dataset params
-    parser.add_argument('--dataset', default='wikitext', choices=['wikitext', 'arxiv'])
+    parser.add_argument('--dataset', default='wikitext', choices=['wikitext', "shakespeare", 'arxiv', "arxiv2000"])
     parser.add_argument('--vocab_size', default=50304, type=int)
+    parser.add_argument("--tokenizer", default="bpe", choices=["bpe", "character"])
     # Model params
     parser.add_argument('--model', default='base', choices=['base', 'sparse-heads-q', 'sparse-heads-qk', 'sparse-tokens-q', 'sparse-tokens-qk'])
     parser.add_argument('--use_pretrained', default="none", type=str) # 'none', 'gpt-2' or a path to the pretraind model

--- a/src/data/arxiv.py
+++ b/src/data/arxiv.py
@@ -1,0 +1,113 @@
+import os
+import tarfile
+import logging
+from pathlib import Path
+from typing import Optional
+from multiprocessing import Pool
+from tempfile import NamedTemporaryFile
+from subprocess import Popen, TimeoutExpired, PIPE
+
+import numpy as np
+import requests
+from tqdm.auto import tqdm
+
+from .tokenizing import encode
+
+def convert_to_markdown(args: tuple[Path, Path]):
+    texfile, mdroot = args
+    mdfile = mdroot/f"{texfile.name}.md"
+    with Popen(["pandoc", "--wrap=none", "--from", "latex", texfile,
+                "--output", mdfile], stderr=PIPE) as proc:
+        try:
+            proc.communicate(timeout=1)
+        except TimeoutExpired:
+            proc.kill()
+
+
+
+def fetch_arxiv(root: Path, year: int):
+    # download latex
+    url = f"https://www.cs.cornell.edu/projects/kddcup/download/hep-th-{year}.tar.gz"
+    texroot = root/"tex"
+    print("Downloading Arxiv year", year)
+    req = requests.get(url, timeout=60)
+    with NamedTemporaryFile(suffix=".tar.gz") as f:
+        f.write(req.content)
+        logging.debug("Tar saved in tempfile %s" % f.name)
+        with tarfile.open(f.name) as tar:
+            logging.debug("Extracting tarfile")
+            tar.extractall(texroot)
+
+    # convert to markdown
+    mdroot = root/"md"/str(year)
+    mdroot.mkdir(parents=True)
+    files = list((texroot/str(year)).iterdir())
+    with Pool(os.cpu_count()) as p:
+        args = [(texfile, mdroot) for texfile in files]
+        for _ in tqdm(p.imap_unordered(convert_to_markdown, args),
+                      desc="Converting to markdown", total=len(files)):
+            pass
+
+
+def tokenize_arxiv(root: Path, tokenizer: str, year: int):
+    tokens = []
+    tokens_val = []
+    tokens_test = []
+    mds = root/"md"/str(year)
+
+    # tokenize
+    desc = f"Tokenizing {year}"
+    for i, mdpath in enumerate(tqdm(list(mds.iterdir()), desc=desc)):
+        with open(mdpath, encoding="utf8") as f:
+            text = "".join(f.readlines())
+        if i % 10 <= 6:  # train split
+            tokens += encode(text, tokenizer)
+        elif i % 10 <= 8:  # val split
+            tokens_val += encode(text, tokenizer)
+        else:  # test split
+            tokens_test += encode(text, tokenizer)
+
+    # save to dir
+    tpath = root/tokenizer/str(year)
+    tpath.mkdir(parents=True)
+    for x, name in zip([tokens, tokens_val, tokens_test],
+                       ["train", "val", "test"]):
+        mem = np.memmap(tpath/f"{name}.npy", dtype=np.uint16, mode="w+",
+                        shape=len(x))
+        for i, v in enumerate(x):
+            mem[i] = v
+
+
+def load_arxiv(cachedir: Path, tokenizer: str, years: Optional[list[int]] = None):
+    all_years = list(range(1992, 2004))
+    if years is None:
+        years = all_years
+    assert set(years) <= set(all_years)
+    root = cachedir/"arxiv"
+    root.mkdir(exist_ok=True, parents=True)
+
+    # download all years requested that are not present
+    for year in years:
+        if not (root/"md"/str(year)).exists():
+            fetch_arxiv(root, year)
+
+    # tokenize all years not previously tokenized
+    for year in years:
+        if not (root/tokenizer/str(year)).exists():
+            tokenize_arxiv(root, tokenizer, year)
+
+    # load meta
+    ret = {}
+    for split in ["train", "val"]:
+        paths = [root/tokenizer/str(year)/f"{split}.npy" for year in years]
+        x = [np.memmap(path, dtype=np.uint16, mode="r") for path in paths]
+        ret[split] = np.concatenate(x)
+    return ret
+
+
+def get_arxiv_2000(tokenizer: str):
+    return load_arxiv(Path(os.path.dirname(__file__))/"datasets", tokenizer, [2000])
+
+
+def get_arxiv_full(tokenizer: str):
+    return load_arxiv(Path(os.path.dirname(__file__))/"datasets", tokenizer)

--- a/src/data/shakespeare.py
+++ b/src/data/shakespeare.py
@@ -1,0 +1,44 @@
+import os
+
+import numpy as np
+import requests
+
+from .tokenizing import encode
+
+
+DATA_PATH = os.path.join(os.path.dirname(__file__), "datasets", "shakespeare")
+
+def get_shakespeare_data(tokenizer: str):
+    """Inspired from https://github.com/karpathy/nanoGPT/"""
+    raw_path = os.path.join(DATA_PATH, "raw.txt")
+    train_path = os.path.join(DATA_PATH, f"train_{tokenizer}.npy")
+    test_path = os.path.join(DATA_PATH, f"test_{tokenizer}.npy")
+
+    # if path is not even there, download all data
+    if not os.path.exists(DATA_PATH):
+        print("Downloading raw Shakespeare texts")
+        url = "https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt"
+        os.makedirs(DATA_PATH, exist_ok=True)
+        text = requests.get(url, timeout=60).text
+        with open(raw_path, "w+", encoding="utf8") as f:
+            f.write(text)
+
+    # attempt to find cached version for current tokenizer
+    if not os.path.exists(train_path) or not os.path.exists(test_path):
+        print("Tokenizing Shakespeare texts")
+        # load text
+        with open(raw_path, encoding="utf8") as f:
+            text = "".join(f.readlines())
+        i = int(0.8*len(text))
+        # encode text
+        x = np.array(encode(text[:i], tokenizer), dtype=np.uint16)
+        x_test = np.array(encode(text[i:], tokenizer), dtype=np.uint16)
+        # map memory
+        mem = np.memmap(train_path, dtype=np.uint16, mode="w+", shape=x.shape)
+        mem[:] = x
+        mem = np.memmap(test_path, dtype=np.uint16, mode="w+", shape=x_test.shape)
+        mem[:] = x_test
+
+    # at this point we know that the binfile was properly created so we load it
+    return {"train": np.memmap(train_path, dtype=np.uint16, mode="r"),
+            "val": np.memmap(test_path, dtype=np.uint16, mode="r")}

--- a/src/data/tokenizing.py
+++ b/src/data/tokenizing.py
@@ -1,0 +1,27 @@
+from string import ascii_letters, digits, punctuation
+
+import tiktoken
+
+
+_char_decode = dict(enumerate(sorted(set(ascii_letters + digits + punctuation + " \n"))))
+_char_encode = {char: i for i, char in _char_decode.items()}
+
+
+def encode(txt: str, tokenizer: str) -> list[int]:
+    """Tokenize `txt` using `tokenizer` {bpe, character} method"""
+    if tokenizer == "bpe":
+        tokenizer = tiktoken.get_encoding("gpt2")
+        return tokenizer.encode(txt)
+    if tokenizer == "character":
+        return [_char_encode[char] for char in txt if char in _char_encode]
+    raise KeyError(f"Tokenizer {tokenizer} unknown")
+
+
+def decode(x: list[int], tokenizer: str) -> str:
+    """Tokenize `txt` using `tokenizer` {bpe, character} method"""
+    if tokenizer == "bpe":
+        tokenizer = tiktoken.get_encoding("gpt2")
+        return tokenizer.decode(x)
+    if tokenizer == "character":
+        return "".join(_char_decode[i] for i in x if i in _char_decode)
+    raise KeyError(f"Tokenizer {tokenizer} unknown")

--- a/src/data/utils.py
+++ b/src/data/utils.py
@@ -1,14 +1,21 @@
 import numpy as np
-import torch
 
+from .shakespeare import get_shakespeare_data
 from .wikitext import get_wikitext_data
+from .arxiv import get_arxiv_2000, get_arxiv_full
 
 
-def get_dataset(args):
+def get_dataset(args) -> dict[str, np.ndarray]:
     """ Fetch the right dataset given by the args.dataset parameter. The logic for each dataset is
-     contained in its own pythin file. The expected format at the moment is a disctionary of np.memmap
+     contained in its own python file. The expected format at the moment is a dictionary of np.memmap
      containing two keys: 'train' and 'val', corresponding to the tokenized training and validation data. """
     if args.dataset == 'wikitext':
         return get_wikitext_data()
+    if args.dataset == "shakespeare":
+        return get_shakespeare_data(args.tokenizer)
+    if args.dataset == "arxiv2000":
+        return get_arxiv_2000(args.tokenizer)
+    if args.dataset == "arxiv":
+        return get_arxiv_full(args.tokenizer)
     else:
         raise NotImplementedError(f"Unknow dataset key '{args.dataset}'")

--- a/src/main.py
+++ b/src/main.py
@@ -38,7 +38,14 @@ def get_exp_name(args):
 
 
 def main(args): 
-
+    # preprocess args
+    if args.vocab_size == 0:  # interpret as "auto", i.e. infer from tokenizer
+        if args.tokenizer == "bpe":
+            args.vocab_size = 50304
+        elif args.tokenizer == "character":
+            args.vocab_size = 96
+        else:
+            raise ValueError(f"Tokenizer {args.tokenizer} expects vocab_size > 0")
 
     torch.backends.cuda.matmul.allow_tf32 = True # allows us to make sure we're able to use tensorfloat32 during training
     torch.backends.cudnn.allow_tf32 = True
@@ -47,9 +54,10 @@ def main(args):
     args = distributed_backend.get_adjusted_args_for_process(args)
 
     args.device = torch.device(args.device)
-    torch.cuda.set_device(args.device)
-    device_type = 'cuda' if 'cuda' in str(args.device) else 'cpu'
-    
+    device_type = "cuda" if "cuda" in str(args.device) else "cpu"
+    if device_type == "cuda":
+        torch.cuda.set_device(args.device)
+
     torch.manual_seed(args.seed)
     random.seed(args.seed)
     np.random.seed(args.seed)
@@ -102,14 +110,13 @@ def main(args):
         del params_copy['device']
         wandb.init(project=args.wandb_project, name=exp_name, config=params_copy)
     
-    ckpt_path = f"{args.results_base_folder}/{args.dataset}/{args.model}/{exp_name}"
+    ckpt_path = os.path.join(args.results_base_folder, args.dataset, args.model, exp_name)
     if not os.path.exists(ckpt_path):
         if distributed_backend.is_master_process():
             os.makedirs(ckpt_path)
-    else:
-        if os.path.isfile(f"{ckpt_path}/summary.json"): # the experiment was already completed
-            print(f"Already found experiment '{ckpt_path}'.\nSkipping.")
-            sys.exit(0)
+    elif os.path.isfile(os.path.join(ckpt_path, "summary.json")): # the experiment was already completed
+        print(f"Already found experiment '{ckpt_path}'.\nSkipping.")
+        sys.exit(0)
 
     if args.model == 'base': # all train functions have the same interface
         train = train_base

--- a/src/optim/utils.py
+++ b/src/optim/utils.py
@@ -8,10 +8,10 @@ def get_batch(data, seq_length, batch_size, device='cpu'):
     ix = torch.randint(len(data) - seq_length, (batch_size,))
     x = torch.stack([torch.from_numpy((data[i:i+seq_length]).astype(np.int64)) for i in ix])
     y = torch.stack([torch.from_numpy((data[i+1:i+1+seq_length]).astype(np.int64)) for i in ix])
-    if device != 'cpu':
+    if "cuda" in torch.device(device).type:
         # pin arrays x,y, which allows us to move them to GPU asynchronously (non_blocking=True)
-        x, y = x.pin_memory().to(device, non_blocking=True), y.pin_memory().to(device, non_blocking=True)
-        #x, y = x.to(device), y.to(device)
+        x = x.pin_memory().to(device, non_blocking=True)
+        y = y.pin_memory().to(device, non_blocking=True)
     return x, y
 
 


### PR DESCRIPTION
Datasets added:
- Shakespare: to use as a light-weight dataset for fast tests. [Source](https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt).
- Arxiv: papers submitted to arxiv in the years 1992-2004 in the [High Energy Physics](https://arxiv.org/archive/hep-th) section. The papers are downloaded as latex files and then **encoded to markdown using pandoc** (i.e. pandoc must be installed to use this dataset).
  This dataset comes in two flavours, `dataset=arxiv`: the entire collection of papers, `dataset=arxiv2000` only the papers submitted in the year 2000.

Tokenizer added:
- Simple character-based tokenizer (encoding numbers, punctuation, upper and lowercase latters and newlines). This might be useful to do lightning tests of some features on low-end devices (i.e. running locally just to make sure it works before submitting a real 

Fixes:
- The previous way to determine if device is cuda in the `get_batch` function was not always correct (namely, when device was a `torch.device` instead of a string).
- Previously, in the main `torch.cuda.set_device`  was always called, even if cuda was not used, which resulted in an error when running on cpu.