### PR TITLE
Update utils.py - Fixed save_checkpoint with scheduler set to None

### DIFF
--- a/src/optim/utils.py
+++ b/src/optim/utils.py
@@ -115,7 +115,7 @@ def save_checkpoint(distributed_backend, model, opt, scheduler, itr, ckpt_path, 
     checkpoint = dict({
         'model': distributed_backend.get_raw_model(model).state_dict(),
         'optimizer': opt.state_dict(),
-        'scheduler': scheduler.state_dict(),
+        'scheduler': scheduler.state_dict() if scheduler != None else None,
         'itr': itr,
     }, **extra_args)
 


### PR DESCRIPTION
The `save_checkpoint` raised an error if scheduler was set to None. This is fixed by setting the scheduler state_dict to None in case the scheduler is not set. 