### PR TITLE
implement torch dataloader

### DIFF
--- a/src/config/base.py
+++ b/src/config/base.py
@@ -9,6 +9,7 @@ def parse_args(base_parser, args, namespace):
     parser.add_argument('--batch_size', default=50, type=int)
     parser.add_argument('--acc_steps', default=4, type=int)
     parser.add_argument('--seed', default=0, type=int)
+    parser.add_argument('--data_seed', default=1337, type=int)
     parser.add_argument('--device', default='cuda:0', type=str)
     parser.add_argument('--iterations', default=15000, type=int)
     parser.add_argument('--lr', default=2e-3, type=float)

--- a/src/config/sparse.py
+++ b/src/config/sparse.py
@@ -8,6 +8,7 @@ def parse_args(base_parser, args, namespace):
     parser.add_argument('--batch_size', default=50, type=int)
     parser.add_argument('--acc_steps', default=4, type=int)
     parser.add_argument('--seed', default=0, type=int)
+    parser.add_argument('--data_seed', default=1337, type=int)
     parser.add_argument('--device', default='cuda:0', type=str)
     parser.add_argument('--iterations', default=15000, type=int)
     parser.add_argument('--lr', default=2e-3, type=float)

--- a/src/data/utils.py
+++ b/src/data/utils.py
@@ -58,15 +58,15 @@ def get_dataloader(data, sequence_length, batch_size, seed=0, distributed_backen
     """Create a DataLoader for the given data. If distributed_backend is provided and is truly
     distributed (world size > 1), the DataLoader will be created with a DistributedSampler that
     splits the data across the processes (in conjunction with DDP).
-    Otherwise, we use a RandomSampler with single shuffling (not every epoch).
+    Otherwise, use a RandomSampler with the specified seed.
+
+    Returns both the dataloader and the sampler.
     """
     dataset = Dataset(data, sequence_length=sequence_length)
     if distributed_backend and distributed_backend.get_world_size() > 1:
         sampler = torch.utils.data.DistributedSampler(
             dataset,
-            shuffle=True,  # note: right now, we don't use `sampler.set_epoch`
-            # in each epoch, which means that the data is not shuffled
-            # across epochs. same ordering is used, which is fine.
+            shuffle=True,
             seed=seed,
         )
     else:
@@ -81,4 +81,4 @@ def get_dataloader(data, sequence_length, batch_size, seed=0, distributed_backen
         sampler=sampler,
         batch_size=batch_size,
     )
-    return loader
+    return loader, sampler

--- a/src/data/utils.py
+++ b/src/data/utils.py
@@ -38,10 +38,14 @@ class Dataset(torch.utils.data.Dataset):
         self.sequence_length = sequence_length
 
     def __len__(self):
-        return len(self.data) - self.sequence_length
+        total_length = len(self.data)
+        # chunk the data into sequences of length `sequence_length`
+        # NOTE: we discard the last remainding sequence if it's not of length `sequence_length`
+        return total_length // self.sequence_length
 
     def __getitem__(self, idx):
         seq_length = self.sequence_length
+        idx = idx * seq_length
         x = torch.from_numpy((self.data[idx : idx + seq_length]).astype(np.int64))
 
         y = torch.from_numpy(

--- a/src/main.py
+++ b/src/main.py
@@ -34,6 +34,7 @@ def get_exp_name(args):
     if 'sparse' in args.model:
         exp_name += f"_lmd{args.lmbda}"
     exp_name += f"_seed={args.seed}"
+    exp_name += f"_data_seed={args.data_seed}"
     return exp_name
 
 
@@ -121,7 +122,7 @@ def main(args):
 
     print(f"\nTraining model={args.model} \n{vars(args)}\n")
 
-    stats = train(model, opt, data, scheduler, args.iterations, args.acc_steps, args.batch_size, args.sequence_length, 
+    stats = train(model, opt, data, args.data_seed, scheduler, args.iterations, args.acc_steps, args.batch_size, args.sequence_length, 
                   eval_freq=args.eval_freq, 
                   distributed_backend=distributed_backend,
                   ckpt_path=f"{ckpt_path}/ckpt.pt", extra_args=args)

--- a/src/optim/base.py
+++ b/src/optim/base.py
@@ -1,4 +1,5 @@
 from contextlib import nullcontext
+from data.utils import get_dataloader
 
 import torch
 import torch.nn.functional as F
@@ -9,11 +10,28 @@ import copy
 from .utils import eval, get_batch, save_checkpoint
 
 
-def train_base(model, opt, data, scheduler, iterations, acc_steps, batch_size, sequence_length, eval_freq, ckpt_path, distributed_backend, extra_args):
+def train_base(model, opt, data, data_seed, scheduler, iterations, acc_steps, batch_size, sequence_length, eval_freq, ckpt_path, distributed_backend, extra_args):
     device_type = 'cuda' if 'cuda' in str(extra_args.device) else 'cpu'
     type_ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(
         device_type=device_type, dtype=torch.bfloat16)  # extra_args.dtype)
     itr, substep, best_val_loss, text_table = 0, 0, float('inf'), None # best_val_loss not used atm, early stopping not recommended but possible 
+
+    data["train"] = get_dataloader(
+        data["train"],
+        sequence_length=sequence_length,
+        batch_size=batch_size,
+        seed=data_seed,
+        distributed_backend=distributed_backend,
+    )
+    data["val"] = get_dataloader(
+        data["val"],
+        sequence_length=sequence_length,
+        batch_size=batch_size,
+        seed=data_seed,
+    )
+
+    data_train_iter = iter(data["train"])
+    data_val_iter = iter(data["val"])
 
     stats = {'train_loss': [], 'val_loss': [], 'val_pp': [], 'val_acc': []}
 
@@ -28,7 +46,7 @@ def train_base(model, opt, data, scheduler, iterations, acc_steps, batch_size, s
     t0 = time.time()
     while itr < iterations:
         for microstep_idx in range(acc_steps):  # gradient accumulation
-            x, y = get_batch(data['train'], sequence_length, batch_size, device=extra_args.device)
+            x, y = get_batch(data_train_iter, device=extra_args.device)
             with type_ctx:
                 with distributed_backend.get_context_for_microstep_forward(model=model, microstep_idx=microstep_idx, gradient_accumulation_steps=acc_steps):
                     outputs = model(x, targets=y)
@@ -53,8 +71,7 @@ def train_base(model, opt, data, scheduler, iterations, acc_steps, batch_size, s
                 model.eval()
                 train_loss = loss.detach().cpu().item() * acc_steps
                 current_lr = scheduler.get_last_lr()[0] if scheduler is not None else extra_args.lr
-                val_acc, val_loss, val_perplexity = eval(model, data['val'], sequence_length, batch_size,
-                                                         extra_args.device, max_num_batches=24, ctx=type_ctx)
+                val_acc, val_loss, val_perplexity = eval(model, data_val_iter, extra_args.device, max_num_batches=24, ctx=type_ctx)
 
                 print_string = f"{epoch}/{itr} [train] loss={train_loss:.3f} [val] loss={val_loss:.3f}, pp={val_perplexity:.2f}, acc={val_acc:3f}"
                 print_string += f" [time per itr] {dt*1000/eval_freq:.2f}ms"


### PR DESCRIPTION
replace the simple iid sampling at each step with a torch dataloader that has its proper seed argument.
the implementation is also in conjunction with the distributed_backend: it uses the DistributedSampler that splits the dataset properly across the processes.

this allows not only reproducibility, but also fixes different models to all see the same data (in the same order) and uses sampling without replacement