### PR TITLE
Eval on a fix subset + better lr decay

### DIFF
--- a/src/config/base.py
+++ b/src/config/base.py
@@ -49,8 +49,8 @@ def parse_args(base_parser, args, namespace):
     parser.add_argument("--muon_backend_steps", default=5, type=int)
     parser.add_argument("--adema_beta3", default=0.9, type=float)
     parser.add_argument("--adema_alpha", default=2.0, type=float)
-    parser.add_argument("--adema_beta3_warmup", default=None, type=Optional[int])
-    parser.add_argument("--adema_alpha_warmup", default=None, type=Optional[int])
+    parser.add_argument("--adema_beta3_warmup", default=None, type=int)
+    parser.add_argument("--adema_alpha_warmup", default=None, type=int)
     # Dataset params
     parser.add_argument(
         "--dataset",

--- a/src/main.py
+++ b/src/main.py
@@ -157,7 +157,7 @@ def main(args):
                 anneal_strategy=args.scheduler,
                 cycle_momentum=False,
                 div_factor=1e2,
-                final_div_factor=0.1,
+                final_div_factor=1,
             )
         else:
             raise NotImplementedError(f"Unknown scheduler type: {args.scheduler}.")

--- a/src/optim/base.py
+++ b/src/optim/base.py
@@ -149,6 +149,7 @@ def train_base(
                     extra_args.device,
                     max_num_batches=eval_steps,
                     ctx=type_ctx,
+                    reset_iterator=True,
                 )
 
                 print_string = f"{epoch}/{itr} [train] loss={train_loss:.3f} [val] loss={val_loss:.3f}, pp={val_perplexity:.2f}, acc={val_acc:3f}"

--- a/src/optim/utils.py
+++ b/src/optim/utils.py
@@ -1,4 +1,5 @@
 from contextlib import ExitStack, contextmanager, nullcontext
+import itertools
 
 import numpy as np
 import torch
@@ -18,8 +19,11 @@ def get_batch(dataloader, device="cpu"):
 
 
 @torch.no_grad()
-def eval(model, data_val_iter, device="cpu", max_num_batches=24, ctx=nullcontext()):
+def eval(model, data_val_iter, device="cpu", max_num_batches=24, ctx=nullcontext(), reset_iterator=False):
     assert model.training == False
+
+    if reset_iterator: # ensure that we always eval on the same batches
+        data_val_iter = itertools.cycle(data_val_iter)
 
     loss_list_val, acc_list = [], []
 


### PR DESCRIPTION
This PR brings two modifications:
- The eval is always done on the same batches, this allows to have smooth validation curves. 
- The lr decay was decaying to 0.1 * max_lr. It has been shown that decaying to 0.01 * max_lr is better. 